### PR TITLE
개빡시다...

### DIFF
--- a/src/main/kotlin/com/albanote/memberservice/MemberServiceApplication.kt
+++ b/src/main/kotlin/com/albanote/memberservice/MemberServiceApplication.kt
@@ -7,10 +7,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import javax.persistence.EntityManager
 
-
+@EnableScheduling
 @SpringBootApplication
 //@SpringBootApplication(exclude= [DataSourceAutoConfiguration::class]) // db 연결 없이 실행 시
 @EnableJpaAuditing

--- a/src/main/kotlin/com/albanote/memberservice/controller/workplace/BossWorkplaceController.kt
+++ b/src/main/kotlin/com/albanote/memberservice/controller/workplace/BossWorkplaceController.kt
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.multipart.MultipartFile
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/workplace")
@@ -105,6 +107,22 @@ class BossWorkplaceController(
         return ResponseEntity.ok(employees)
     }
 
+    /** 일별 근무 기록 조회 **/
+    @GetMapping("/workRecordByDate")
+    fun getWorkRecordByDate(
+        @RequestParam workplaceId: Long,
+        @RequestParam date: LocalDate
+    ): ResponseEntity<MutableList<WorkRecordResponseDTO>> {
+        val workRecords = workplaceService.getWorkRecordByDate(workplaceId, date)
+
+        return ResponseEntity.ok(workRecords)
+    }
+
+    @GetMapping("/wrokRecordDetail")
+    fun getWorkRecordDetail(@RequestParam workRecordId: Long){
+        workplaceService.getWorkRecordDetail(workRecordId)
+    }
+
     /*********************   post   *********************/
 
     /** 일터 생성 **/
@@ -116,9 +134,22 @@ class BossWorkplaceController(
     }
 
     /** 일터 사진 등록 **/
-    @PostMapping("/createTodoReferenceImage")
-    fun postCreateWorkplaceImage(@RequestParam todoId: Long) {
-        //todo
+    @PostMapping("/createWorkplaceImage")
+    fun postCreateWorkplaceImage(
+        @RequestParam workplaceId: Long,
+        @RequestParam("file") file: MultipartFile
+    ): ResponseEntity<String> {
+        val imageUrl = workplaceService.postCreateWorkplaceImage(workplaceId, file)
+
+        return ResponseEntity.ok(imageUrl)
+    }
+
+    /** 직책 생성 **/
+    @PostMapping("/createEmployeeRank")
+    fun postCreateEmployeeRank(@RequestBody dto: CreateEmployeeRankResponseDTO): ResponseEntity<Long> {
+        val rankId = workplaceService.postCreateEmployeeRank(dto)
+
+        return ResponseEntity.ok(rankId)
     }
 
     /** 할 일 생성 **/
@@ -131,7 +162,11 @@ class BossWorkplaceController(
 
     /** 할 일 참조 사진 등록 **/
     @PostMapping("/createTodoReferenceImage")
-    fun postCreateTodoReferenceImage(@RequestParam todoId: Long) {
+    fun postCreateTodoReferenceImage(
+        @RequestParam workplaceId: Long,
+        @RequestParam("file") file: MultipartFile
+    ) {
+        workplaceService.postCreateTodoReferenceImage(workplaceId, file)
         //todo
     }
 
@@ -155,6 +190,14 @@ class BossWorkplaceController(
         return ResponseEntity.ok(todoId)
     }
 
+    /** 직책 정보 수정 **/
+    @PutMapping("/modifyEmployeeRank")
+    fun putModifyEmployeeRank(@RequestBody dto: ModifyEmployeeRankResponseDTO): ResponseEntity<Long> {
+        val rankId = workplaceService.putModifyEmployeeRank(dto)
+
+        return ResponseEntity.ok(rankId)
+    }
+
     /************************ delete **************************/
 
     /** 일터 비활성화 **/
@@ -169,6 +212,14 @@ class BossWorkplaceController(
     @DeleteMapping("/deleteTodo")
     fun deleteDeleteTodo(@RequestParam todoId: Long): ResponseEntity<Boolean> {
         val result = workplaceService.deleteDeleteTodo(todoId)
+
+        return ResponseEntity.ok(result)
+    }
+
+    /** 직책 삭제 **/
+    @DeleteMapping("/deleteEmployeeRank")
+    fun deleteDeleteEmployeeRank(@RequestParam rankId: Long): ResponseEntity<Boolean> {
+        val result = workplaceService.deleteDeleteEmployeeRank(rankId)
 
         return ResponseEntity.ok(result)
     }

--- a/src/main/kotlin/com/albanote/memberservice/controller/workplace/EmployeeWorkplaceController.kt
+++ b/src/main/kotlin/com/albanote/memberservice/controller/workplace/EmployeeWorkplaceController.kt
@@ -1,0 +1,5 @@
+package com.albanote.memberservice.controller.workplace
+
+
+class EmployeeWorkplaceController {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/QueryDslPairDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/QueryDslPairDTO.kt
@@ -1,0 +1,9 @@
+package com.albanote.memberservice.domain.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+class QueryDslPairDTO @QueryProjection constructor(
+    val first: Any?,
+    val second: Any?
+) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/QueryDslTripleDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/QueryDslTripleDTO.kt
@@ -1,0 +1,10 @@
+package com.albanote.memberservice.domain.dto
+
+import com.querydsl.core.annotations.QueryProjection
+
+class QueryDslTripleDTO @QueryProjection constructor(
+    val first: Any?,
+    val second: Any?,
+    val third: Any?
+) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/query/workplace/EmployeeDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/query/workplace/EmployeeDTO.kt
@@ -1,0 +1,11 @@
+package com.albanote.memberservice.domain.dto.query.workplace
+
+class EmployeeDTO(
+    val id: Long,
+    val memberId: Long,
+    val workplaceId: Long,
+    val employeeRankId :Long,
+    val employeeTodoIds: List<Long>,
+
+) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/request/workplace/CreateCommuteTimeByDayOfWeekResponseDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/request/workplace/CreateCommuteTimeByDayOfWeekResponseDTO.kt
@@ -1,0 +1,24 @@
+package com.albanote.memberservice.domain.dto.request.workplace
+
+import com.albanote.memberservice.domain.entity.workplace.CommuteTimeByDayOfWeek
+import com.albanote.memberservice.domain.entity.workplace.EmployeeRank
+import java.time.LocalTime
+
+/**
+ * 요일별 출퇴근 시간 다르게 생성 요청 DTO
+ * */
+class CreateCommuteTimeByDayOfWeekResponseDTO(
+    // 해당 요일 월,화,수 -> 111____
+    val dayOfWeek: String,
+    val officeGoingTime: LocalTime,
+    val quittingTime: LocalTime
+) {
+    fun convertToEntity(rank: EmployeeRank): CommuteTimeByDayOfWeek {
+        return CommuteTimeByDayOfWeek(
+            employeeRank = rank,
+            dayOfWeek = dayOfWeek,
+            officeGoingTime = officeGoingTime,
+            quittingTime = quittingTime
+        )
+    }
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/request/workplace/CreateEmployeeRankResponseDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/request/workplace/CreateEmployeeRankResponseDTO.kt
@@ -1,0 +1,77 @@
+package com.albanote.memberservice.domain.dto.request.workplace
+
+import com.albanote.memberservice.domain.entity.workplace.EmployeeRank
+import com.albanote.memberservice.domain.entity.workplace.Workplace
+import com.albanote.memberservice.domain.entity.workplace.work.PayrollCycleType
+import com.albanote.memberservice.domain.entity.workplace.work.PayrollType
+import com.albanote.memberservice.domain.entity.workplace.work.WorkRecordType
+import java.time.LocalTime
+
+/**
+ * 직급 생성 요청 DTO
+ * */
+class CreateEmployeeRankResponseDTO(
+    val workplaceId: Long,
+
+    val payrollType: PayrollType,
+    val payrollCycle: PayrollCycleType,
+
+    val ordinaryHourlyWage: Int,
+
+    val name: String,
+    val salary: Int,
+    val hourlyWageCalculationUnit: Int,
+    val officeGoingTime: LocalTime?,
+    val quittingTime: LocalTime?,
+    val breakTime: Int,
+
+    val workingDay: String,
+    var isCommuteTimeVaryByDayOfWeek: Boolean,
+    val commuteTimeByDateOfWeek: List<CreateCommuteTimeByDayOfWeekResponseDTO>,
+
+    val paidHoliday: String,
+    var payday: Int,
+    var settlementDate: Int,
+
+    var workRecordType: WorkRecordType,
+
+    var isWorkApprovalRequirement: Boolean,
+    var isNightAllowance: Boolean,
+    var nightAllowanceExtraMultiples: Float,
+    var isOvertimeAllowance: Boolean,
+    var overtimeAllowanceExtraMultiples: Float,
+    var isHolidayAllowance: Boolean,
+    var holidayAllowanceExtraMultiples: Float
+) {
+
+    fun convertToEntity(): EmployeeRank {
+        val rank = EmployeeRank(
+            workplace = Workplace(workplaceId),
+            name = name,
+            isBoss = false,
+            payrollType = payrollType,
+            salary = salary,
+            payrollCycle = payrollCycle,
+            ordinaryHourlyWage = ordinaryHourlyWage,
+            hourlyWageCalculationUnit = hourlyWageCalculationUnit,
+            officeGoingTime = officeGoingTime,
+            quittingTime = quittingTime,
+            breakTime = breakTime,
+            workingDay = workingDay,
+            paidHoliday = paidHoliday,
+            payday = payday,
+            settlementDate = settlementDate,
+            workRecordType = workRecordType,
+            isCommuteTimeVaryByDayOfWeek = isCommuteTimeVaryByDayOfWeek,
+            isWorkApprovalRequirement = isWorkApprovalRequirement,
+            isNightAllowance = isNightAllowance,
+            nightAllowanceExtraMultiples = nightAllowanceExtraMultiples,
+            isOvertimeAllowance = isOvertimeAllowance,
+            overtimeAllowanceExtraMultiples = overtimeAllowanceExtraMultiples,
+            isHolidayAllowance = isHolidayAllowance,
+            holidayAllowanceExtraMultiples = holidayAllowanceExtraMultiples
+        )
+
+        return rank
+    }
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/request/workplace/ModifyEmployeeRankResponseDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/request/workplace/ModifyEmployeeRankResponseDTO.kt
@@ -1,0 +1,77 @@
+package com.albanote.memberservice.domain.dto.request.workplace
+
+import com.albanote.memberservice.domain.entity.workplace.EmployeeRank
+import com.albanote.memberservice.domain.entity.workplace.Workplace
+import com.albanote.memberservice.domain.entity.workplace.work.PayrollCycleType
+import com.albanote.memberservice.domain.entity.workplace.work.PayrollType
+import com.albanote.memberservice.domain.entity.workplace.work.WorkRecordType
+import java.time.LocalTime
+
+/**
+ * 직급 수정 요청 DTO
+ * */
+class ModifyEmployeeRankResponseDTO(
+    val workplaceId: Long,
+
+    val rankId: Long,
+
+    val payrollType: PayrollType,
+    val payrollCycle: PayrollCycleType,
+
+    val ordinaryHourlyWage: Int,
+
+    val name: String,
+    val salary: Int,
+    val hourlyWageCalculationUnit: Int,
+    val officeGoingTime: LocalTime?,
+    val quittingTime: LocalTime?,
+    val breakTime: Int,
+
+    val workingDay: String,
+    var isCommuteTimeVaryByDayOfWeek: Boolean,
+    val commuteTimeByDateOfWeek: List<CreateCommuteTimeByDayOfWeekResponseDTO>,
+
+    val paidHoliday: String,
+    var payday: Int,
+    var settlementDate: Int,
+
+    var workRecordType: WorkRecordType,
+
+    var isWorkApprovalRequirement: Boolean,
+    var isNightAllowance: Boolean,
+    var nightAllowanceExtraMultiples: Float,
+    var isOvertimeAllowance: Boolean,
+    var overtimeAllowanceExtraMultiples: Float,
+    var isHolidayAllowance: Boolean,
+    var holidayAllowanceExtraMultiples: Float
+) {
+
+    fun convertToEntity(): EmployeeRank {
+        return EmployeeRank(
+            workplace = Workplace(workplaceId),
+            name = name,
+            isBoss = false,
+            payrollType = payrollType,
+            salary = salary,
+            payrollCycle = payrollCycle,
+            ordinaryHourlyWage = ordinaryHourlyWage,
+            hourlyWageCalculationUnit = hourlyWageCalculationUnit,
+            officeGoingTime = officeGoingTime,
+            quittingTime = quittingTime,
+            breakTime = breakTime,
+            workingDay = workingDay,
+            paidHoliday = paidHoliday,
+            payday = payday,
+            settlementDate = settlementDate,
+            workRecordType = workRecordType,
+            isCommuteTimeVaryByDayOfWeek = isCommuteTimeVaryByDayOfWeek,
+            isWorkApprovalRequirement = isWorkApprovalRequirement,
+            isNightAllowance = isNightAllowance,
+            nightAllowanceExtraMultiples = nightAllowanceExtraMultiples,
+            isOvertimeAllowance = isOvertimeAllowance,
+            overtimeAllowanceExtraMultiples = overtimeAllowanceExtraMultiples,
+            isHolidayAllowance = isHolidayAllowance,
+            holidayAllowanceExtraMultiples = holidayAllowanceExtraMultiples
+        )
+    }
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/response/workplace/WorkRecordDetailResponseDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/response/workplace/WorkRecordDetailResponseDTO.kt
@@ -1,0 +1,12 @@
+package com.albanote.memberservice.domain.dto.response.workplace
+
+import com.querydsl.core.annotations.QueryProjection
+
+/**
+ * 근무 상세 기록 조회 요청 DTO
+ * */
+class WorkRecordDetailResponseDTO @QueryProjection constructor(
+    val workRecordId: Long,
+
+) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/dto/response/workplace/WorkRecordResponseDTO.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/dto/response/workplace/WorkRecordResponseDTO.kt
@@ -1,5 +1,6 @@
 package com.albanote.memberservice.domain.dto.response.workplace
 
+import com.albanote.memberservice.domain.entity.workplace.work.WorkType
 import com.querydsl.core.annotations.QueryProjection
 import java.time.LocalTime
 
@@ -10,4 +11,5 @@ class WorkRecordResponseDTO @QueryProjection constructor(
     val currentEmployee: EmployeeMemberSimpleResponseDTO,
     val officeGoingTime: LocalTime?,
     val quittingTime: LocalTime?,
+    val workType: WorkType
 )

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/EmployeeMemberRank.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/EmployeeMemberRank.kt
@@ -1,0 +1,27 @@
+package com.albanote.memberservice.domain.entity.workplace
+
+import com.albanote.memberservice.domain.entity.BaseEntity
+import java.time.LocalDate
+import javax.persistence.*
+
+
+@Entity
+@AttributeOverride(name = "id", column = Column(name = "employee_member_rank_id"))
+class EmployeeMemberRank(
+    id: Long? = null,
+
+    @Column(nullable = false)
+    var createdDate: LocalDate? = null,
+    @Column(nullable = true)
+    var deprecatedDate: LocalDate? = null,
+
+    @JoinColumn(name = "employee_member_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    val employeeMember: EmployeeMember,
+
+    @JoinColumn(name = "employee_rank_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    val employeeRank: EmployeeRank
+
+) : BaseEntity(id) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/EmployeeRank.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/EmployeeRank.kt
@@ -4,6 +4,7 @@ import com.albanote.memberservice.domain.entity.BaseEntity
 import com.albanote.memberservice.domain.entity.workplace.work.PayrollCycleType
 import com.albanote.memberservice.domain.entity.workplace.work.PayrollType
 import com.albanote.memberservice.domain.entity.workplace.work.WorkRecordType
+import java.time.LocalDate
 import java.time.LocalTime
 import javax.persistence.*
 
@@ -48,8 +49,8 @@ class EmployeeRank(
     var ordinaryHourlyWage: Int? = null,
     // 시급 계산 단위 (분)
     val hourlyWageCalculationUnit: Int? = null,
-    // 시급 계산 반올림,버림
-    val isHourlyWageCalculationRound: Boolean? = null,
+//    // 시급 계산 반올림,버림
+//    val isHourlyWageCalculationRound: Boolean? = null,
 
     // 출퇴근 시간
     val officeGoingTime: LocalTime? = null,
@@ -62,14 +63,14 @@ class EmployeeRank(
     @Column(columnDefinition = "TEXT", nullable = true)
     val workingDay: String? = null,
 
-    // 유급 요일 (MTWTFSS) 출근하는 날 _ ex) 일 유급 휴일 -> ______1
+    // 유급 요일 1 (MTWTFSS) 출근하는 날 _ ex) 일 유급 휴일 -> ______1
     @Column(columnDefinition = "TEXT", nullable = true)
     val paidHoliday: String? = null,
 
-    // 급여일 수요일 -> 3, 5일 -> 5
+    // 급여일 수요일 -> 3, 5일 -> 5, 말일 -> 32
     var payday: Int? = null,
 
-    // 급여 정산일  월 ~ 일 -> 7, 1일 까지 -> 1
+    // 급여 정산 기준일  월 ~ 일 -> 7, 1일 까지 -> 1
     var settlementDate: Int? = null,
 
     // 근무 기록 방식
@@ -80,15 +81,18 @@ class EmployeeRank(
     // 출퇴근 시간 요일별로 다른지 여부
     var isCommuteTimeVaryByDayOfWeek: Boolean? = null,
     @OneToMany(mappedBy = "dayOfWeek")
-    val commuteTimeByDateOfWeek: MutableList<CommuteTimeByDayOfWeek> = mutableListOf(),
+    var commuteTimeByDayOfWeek: MutableList<CommuteTimeByDayOfWeek> = mutableListOf(),
 
     // 근무 승인 필수 여부
     var isWorkApprovalRequirement: Boolean? = null,
     // 야간 수당
     var isNightAllowance: Boolean? = null,
+    var nightAllowanceExtraMultiples: Float? = null,
     // 초과 수당
     var isOvertimeAllowance: Boolean? = null,
+    var overtimeAllowanceExtraMultiples: Float? = null,
     // 휴일 수당
     var isHolidayAllowance: Boolean? = null,
+    var holidayAllowanceExtraMultiples: Float? = null
 ) : BaseEntity(id) {
 }

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/Workplace.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/Workplace.kt
@@ -64,8 +64,9 @@ class Workplace(
     @OneToMany(mappedBy = "workplace")
     val workplaceRequests: MutableList<WorkplaceRequest> = mutableListOf(),
 
-    @Column(columnDefinition = "TEXT", nullable = true)
-    val imageUrl: String? = null
+    @JoinColumn(name = "workplace_image_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    val workplaceImage: WorkplaceImage? = null
 ) : BaseTimeEntity(id) {
 
 }

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/WorkplaceImage.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/WorkplaceImage.kt
@@ -1,0 +1,21 @@
+package com.albanote.memberservice.domain.entity.workplace
+
+import com.albanote.memberservice.domain.entity.BaseEntity
+import javax.persistence.*
+
+/**
+ * 일터 이미지
+ * */
+@Entity
+@AttributeOverride(name = "id", column = Column(name = "workplace_image_id"))
+class WorkplaceImage(
+    id: Long? = null,
+
+    @JoinColumn(name = "workplace_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    val workplace: Workplace? = null,
+
+    @Column(columnDefinition = "TEXT", nullable = true)
+    val imageUrl: String? = null
+) : BaseEntity(id) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/Todo.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/Todo.kt
@@ -36,8 +36,8 @@ class Todo(
     @OneToMany(mappedBy = "todo")
     var chargeEmployee: MutableList<EmployeeTodo> = mutableListOf(),
 
-    @Column(columnDefinition = "TEXT", nullable = true)
-    var referenceImageUrl: String? = null,
+    @OneToMany(mappedBy = "todo")
+    var referenceImages: MutableList<TodoReferenceImage> = mutableListOf(),
 
     // 인증사진 필수 여부
     var isAuthenticationImageRequire: Boolean? = null,

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/TodoReferenceImage.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/TodoReferenceImage.kt
@@ -1,0 +1,21 @@
+package com.albanote.memberservice.domain.entity.workplace.work
+
+import com.albanote.memberservice.domain.entity.BaseEntity
+import javax.persistence.*
+
+/**
+ * 할일 참조 사진
+ * */
+@Entity
+@AttributeOverride(name = "id", column = Column(name = "todo_reference_image_id"))
+class TodoReferenceImage(
+    id: Long? = null,
+
+    @JoinColumn(name = "todo_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    val todo: Todo? = null,
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    val imageUrl: String? = null
+) : BaseEntity(id) {
+}

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/WorkRecord.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/WorkRecord.kt
@@ -2,6 +2,7 @@ package com.albanote.memberservice.domain.entity.workplace.work
 
 import com.albanote.memberservice.domain.entity.BaseEntity
 import com.albanote.memberservice.domain.entity.workplace.EmployeeMember
+import com.albanote.memberservice.domain.entity.workplace.EmployeeMemberRank
 import com.albanote.memberservice.domain.entity.workplace.Workplace
 import java.time.LocalDate
 import java.time.LocalTime
@@ -13,28 +14,27 @@ import javax.persistence.*
 class WorkRecord(
     id: Long? = null,
 
-    // todo 할 일, 직책 정보 변경 시 어떻게 대응?
-    // 현재는 할 일, 근무 내역이 모두 남기는게 아니고 완료된것만 남기므로 할 일, 직책 정보에서 등록되지 않은 데이터 유추해서 가져오고 있음...
-    // 수정에 깔끔하게 대응하는방법은 매번 모든 할 일, 근무 내역을 남기는 방법인데 이럴경우 불필요한 데이터가 너무 쌓이게 되고
-    // 그럴바엔 수정을 할 때 기존 정보를 오래된 데이터로 보내고 최신데이터로 사용하게?
-    // 근데 직원의 직책이 바뀌면 과거 직책이 안 남음으로 유추할 수 없음... 다 남겨야하나...
-
     @JoinColumn(name = "employee_member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     var employeeMember: EmployeeMember? = null,
+
+    @JoinColumn(name = "employee_member_rank_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    var employeeRankMember: EmployeeMemberRank? = null,
 
     @JoinColumn(name = "workplace_id")
     @ManyToOne(fetch = FetchType.LAZY)
     var workplace: Workplace? = null,
 
-    // 근무 유형
+// 근무 유형
     @Enumerated(EnumType.STRING)
     @Column(columnDefinition = "TEXT", nullable = true)
     var workType: WorkType? = null,
 
-    // 근무 날짜
+// 근무 날짜
     val workDate: LocalDate? = null,
-    // 출퇴근 시간
+
+// 출퇴근 시간
     val officeGoingTime: LocalTime? = null,
     val quittingTime: LocalTime? = null,
 

--- a/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/WorkType.kt
+++ b/src/main/kotlin/com/albanote/memberservice/domain/entity/workplace/work/WorkType.kt
@@ -1,5 +1,5 @@
 package com.albanote.memberservice.domain.entity.workplace.work
 
 enum class WorkType {
-    WORK, LATE, HOLIDAY, PAID_HOLIDAY, ABSENT
+    BEFORE_WORK, WORKING, WORKED, LATE, HOLIDAY, PAID_HOLIDAY, ABSENT
 }

--- a/src/main/kotlin/com/albanote/memberservice/repository/RepositorySupport.kt
+++ b/src/main/kotlin/com/albanote/memberservice/repository/RepositorySupport.kt
@@ -14,28 +14,28 @@ import org.springframework.data.support.PageableExecutionUtils
 
 open class RepositorySupport {
     @Autowired
-    lateinit var queryFactory: JPAQueryFactory
+    protected lateinit var queryFactory: JPAQueryFactory
 
-    fun <T> select(expr: Expression<T>): JPAQuery<T> = queryFactory.select(expr)
-    fun <T> selectFrom(path: EntityPath<T>): JPAQuery<T> = queryFactory.selectFrom(path)
-    fun <T> delete(path: EntityPath<T>): JPADeleteClause = queryFactory.delete(path)
-    fun <T> update(path: EntityPath<T>): JPAUpdateClause = queryFactory.update(path)
+    protected fun <T> select(expr: Expression<T>): JPAQuery<T> = queryFactory.select(expr)
+    protected fun <T> selectFrom(path: EntityPath<T>): JPAQuery<T> = queryFactory.selectFrom(path)
+    protected fun <T> delete(path: EntityPath<T>): JPADeleteClause = queryFactory.delete(path)
+    protected fun <T> update(path: EntityPath<T>): JPAUpdateClause = queryFactory.update(path)
 
-    fun <T> JPAQuery<T>.pageableOption(pageable: Pageable): JPAQuery<T> {
+    protected fun <T> JPAQuery<T>.pageableOption(pageable: Pageable): JPAQuery<T> {
         this.offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
         return this
     }
 
     // content 와 count 쿼리가 같을경우 -> count 쿼리만 받고 pageOption 만 추가해서 페이지 번환
-    fun <T> JPAQuery<T>.pageableCountUtilAndFetch(pageable: Pageable): Page<T> {
+    protected fun <T> JPAQuery<T>.pageableCountUtilAndFetch(pageable: Pageable): Page<T> {
         val content = this.pageableOption(pageable).fetch()
         return PageableExecutionUtils.getPage(content, pageable) { this.fetchCount() }
     }
 
     // content 와 count 쿼리가 다를경우 -> count 쿼리와 content 쿼리 다 받고 pageOption 만 추가해서 페이지 번환
-    fun <T, F> JPAQuery<T>.pageableCountUtilAndFetch(pageable: Pageable, func: () -> JPAQuery<F>): Page<T> {
+    protected fun <T, F> JPAQuery<T>.pageableCountUtilAndFetch(pageable: Pageable, func: () -> JPAQuery<F>): Page<T> {
         val content = this.pageableOption(pageable).fetch()
-        return PageableExecutionUtils.getPage(content, pageable) { func.invoke().fetchCount()}
+        return PageableExecutionUtils.getPage(content, pageable) { func.invoke().fetchCount() }
     }
 }

--- a/src/main/kotlin/com/albanote/memberservice/repository/workplace/WorkplaceScheduleRepository.kt
+++ b/src/main/kotlin/com/albanote/memberservice/repository/workplace/WorkplaceScheduleRepository.kt
@@ -1,0 +1,100 @@
+package com.albanote.memberservice.repository.workplace
+
+import com.albanote.memberservice.domain.dto.QQueryDslPairDTO
+import com.albanote.memberservice.domain.dto.QueryDslPairDTO
+import com.albanote.memberservice.domain.entity.workplace.QCommuteTimeByDayOfWeek.commuteTimeByDayOfWeek
+import com.albanote.memberservice.domain.entity.workplace.QEmployeeMember.employeeMember
+import com.albanote.memberservice.domain.entity.workplace.QEmployeeRank.employeeRank
+import com.albanote.memberservice.domain.entity.workplace.work.QWorkRecord.workRecord
+import com.albanote.memberservice.domain.entity.workplace.work.WorkType
+import com.albanote.memberservice.repository.RepositorySupport
+import org.springframework.jdbc.core.BatchPreparedStatementSetter
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.PreparedStatement
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Repository
+class WorkplaceScheduleRepository(
+    private val jdbcTemplate: JdbcTemplate
+) : RepositorySupport() {
+
+    fun setAbsentWorkRecord() {
+        val absentEmployeeRankIds = select(employeeRank.id)
+            .from(employeeRank)
+            .where(
+                employeeRank.quittingTime.gt(LocalTime.now().minusMinutes(5)),
+                employeeRank.quittingTime.lt(LocalTime.now().plusMinutes(5))
+            ).fetch()
+            .toMutableList()
+
+        absentEmployeeRankIds.addAll(
+            select(commuteTimeByDayOfWeek.employeeRank.id)
+                .from(commuteTimeByDayOfWeek)
+                .where(
+                    commuteTimeByDayOfWeek.quittingTime.gt(LocalTime.now().minusMinutes(5)),
+                    commuteTimeByDayOfWeek.quittingTime.lt(LocalTime.now().plusMinutes(5))
+                ).fetch()
+        )
+
+        val absentEmployeeMemberIds = select(QQueryDslPairDTO(employeeMember.id, employeeMember.workplace.id))
+            .from(employeeMember)
+            .where(employeeMember.employeeRank.id.`in`(absentEmployeeRankIds))
+            .fetch()
+
+        val excludeEmployeeIds = select(workRecord.employeeMember.id)
+            .from(workRecord)
+            .where(
+                workRecord.workType.ne(WorkType.ABSENT),
+                workRecord.workDate.eq(LocalDate.now())
+            ).fetch()
+
+        val absentWorkRecords = absentEmployeeMemberIds.filter { !excludeEmployeeIds.contains(it.first as Long) }
+        workRecordBatchInsert(absentWorkRecords, WorkType.ABSENT)
+    }
+
+    /** 주휴 휴무 기록 생성 **/
+    fun setPaidHolidayWorkRecord() {
+        val dayOfWeek = LocalDate.now().dayOfWeek.value
+        val paidHolidayEmployeeRankIds = select(employeeRank.id)
+            .from(employeeRank)
+            .where(employeeRank.paidHoliday.substring(dayOfWeek - 1, dayOfWeek).eq("1"))
+            .fetch()
+        val paidHolidayEmployeeMemberIds = select(QQueryDslPairDTO(employeeMember.id, employeeMember.workplace.id))
+            .from(employeeMember)
+            .where(employeeMember.employeeRank.id.`in`(paidHolidayEmployeeRankIds))
+            .fetch()
+
+        val holidayEmployeeRankIds = select(employeeRank.id)
+            .from(employeeRank)
+            .where(employeeRank.workingDay.substring(dayOfWeek - 1, dayOfWeek).eq("_"))
+            .fetch()
+        val holidayEmployeeMemberIds = select(QQueryDslPairDTO(employeeMember.id, employeeMember.workplace.id))
+            .from(employeeMember)
+            .where(employeeMember.employeeRank.id.`in`(holidayEmployeeRankIds))
+            .fetch()
+
+        workRecordBatchInsert(paidHolidayEmployeeMemberIds, WorkType.PAID_HOLIDAY)
+        workRecordBatchInsert(holidayEmployeeMemberIds, WorkType.HOLIDAY)
+    }
+
+    fun workRecordBatchInsert(
+        employeeIdAndWorkplaceIdPair: List<QueryDslPairDTO>,
+        workType: WorkType,
+        pay: Int = 0
+    ) {
+        val sql =
+            "INSERT INTO WORK_RECORD (employee_member_id, workplace_id, work_type, work_date, pay) VALUES (?,?,?,?,?)"
+        jdbcTemplate.batchUpdate(sql, object : BatchPreparedStatementSetter {
+            override fun getBatchSize(): Int = employeeIdAndWorkplaceIdPair.size
+            override fun setValues(ps: PreparedStatement, i: Int) {
+                ps.setLong(1, employeeIdAndWorkplaceIdPair[i].first as Long)
+                ps.setLong(2, employeeIdAndWorkplaceIdPair[i].second as Long)
+                ps.setString(3, workType.name)
+                ps.setDate(4, java.sql.Date.valueOf(LocalDate.now()))
+                ps.setInt(5, pay)
+            }
+        })
+    }
+}

--- a/src/main/kotlin/com/albanote/memberservice/scheduler/WorkplaceSchedule.kt
+++ b/src/main/kotlin/com/albanote/memberservice/scheduler/WorkplaceSchedule.kt
@@ -1,0 +1,23 @@
+package com.albanote.memberservice.scheduler
+
+import com.albanote.memberservice.service.workplace.WorkplaceScheduleService
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+@Component
+class WorkplaceSchedule(
+    private val workplaceScheduleService: WorkplaceScheduleService
+) {
+
+    /** 결근 기록 생성 **/
+    @Scheduled(cron = "0 0/10 * * * ?")
+    fun scheduleMakeAbsentRecord() {
+        workplaceScheduleService.setAbsentWorkRecord()
+    }
+
+    /** 주휴 휴무 기록 생성 **/
+    @Scheduled(cron = "0 0 0/1 * * ?")
+    fun scheduleMakeHolidayRecord() {
+        workplaceScheduleService.setPaidHolidayWorkRecord()
+    }
+}

--- a/src/main/kotlin/com/albanote/memberservice/service/S3Service.kt
+++ b/src/main/kotlin/com/albanote/memberservice/service/S3Service.kt
@@ -63,9 +63,9 @@ class S3Service {
     private val zipFileType = "zip"
     private val pdfFileType = "pdf"
 
-    val chattingRoomImage = "chatting_room_image"
-    val chattingMessageFile = "chatting_message_file"
     val memberProfileImage = "member_profile_image"
+    val workplaceImage = "workplace_image"
+    val workplaceTodoImage = "workplace_todo_image"
 
     fun imageUpload(
         file: MultipartFile,

--- a/src/main/kotlin/com/albanote/memberservice/service/workplace/WorkplaceScheduleService.kt
+++ b/src/main/kotlin/com/albanote/memberservice/service/workplace/WorkplaceScheduleService.kt
@@ -1,0 +1,24 @@
+package com.albanote.memberservice.service.workplace
+
+import com.albanote.memberservice.repository.workplace.WorkplaceScheduleRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class WorkplaceScheduleService(
+    val workplaceScheduleRepository: WorkplaceScheduleRepository
+) {
+
+    /** 결근 기록 생성 **/
+    @Transactional
+    fun setAbsentWorkRecord() {
+        workplaceScheduleRepository.setAbsentWorkRecord()
+    }
+
+    /** 주휴 휴무 기록 생성 **/
+    @Transactional
+    fun setPaidHolidayWorkRecord(){
+        workplaceScheduleRepository.setPaidHolidayWorkRecord()
+    }
+}

--- a/src/test/kotlin/com/albanote/memberservice/repository/WorkplaceRepositoryTest.kt
+++ b/src/test/kotlin/com/albanote/memberservice/repository/WorkplaceRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.albanote.memberservice.repository
 
+import com.albanote.memberservice.repository.workplace.BossWorkplaceRepository
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest

--- a/src/test/kotlin/com/albanote/memberservice/service/workplace/BossWorkplaceServiceTest.kt
+++ b/src/test/kotlin/com/albanote/memberservice/service/workplace/BossWorkplaceServiceTest.kt
@@ -1,0 +1,20 @@
+package com.albanote.memberservice.service.workplace
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+internal class BossWorkplaceServiceTest {
+    @Autowired
+    lateinit var bossWorkplaceService: BossWorkplaceService
+
+    @Test
+    fun fs() {
+        val memberId = 10L
+        val list = bossWorkplaceService.getWorkplaceList(memberId)
+        list.forEach {
+
+        }
+    }
+}

--- a/src/test/kotlin/com/albanote/memberservice/service/workplace/WorkplaceScheduleServiceTest.kt
+++ b/src/test/kotlin/com/albanote/memberservice/service/workplace/WorkplaceScheduleServiceTest.kt
@@ -1,0 +1,18 @@
+package com.albanote.memberservice.service.workplace
+
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.Commit
+
+@SpringBootTest
+internal class WorkplaceScheduleServiceTest{
+    @Autowired
+    lateinit var workplaceScheduleService: WorkplaceScheduleService
+
+    @Test
+    @Commit
+    fun 결근_기록_생성(){
+        workplaceScheduleService.setAbsentWorkRecord()
+    }
+}


### PR DESCRIPTION
직급 - 수정, 삭제 시 기존 기록 보존, deprecatedDate 에 수정 날짜 기록
직원 - 직급<->직원 연결하는 entity 로 직원은 매번 새로 생성 및 수정 없이 해당 entity 를 통해 당시의 직급 상태 조회 가능, 직급이 수정되면 해당 entity 는 무조건 새로 생성
근무 내역 - 근무를 직접 기록하는거 외(미출근, 주휴휴무 등)에는 저장하지않고 직급 및 직원 과거 정보들 조합해서 조회 가능하도록